### PR TITLE
Add LockedCustardCommand to allow locking of a custard command to only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 1.1
+* Added `LockedCustardCommand` which uses a file lock in `TEMP_DIR` to lock a custard command to only run one at a time
+
 ### 1.0.12
 * Removed: phpdocumentor/reflection-docblock dependency 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-### 1.1
+### 1.1.0
+
 * Added `LockedCustardCommand` which uses a file lock in `TEMP_DIR` to lock a custard command to only run one at a time
 
 ### 1.0.12
+
 * Removed: phpdocumentor/reflection-docblock dependency 
 
 ### 1.0.9

--- a/src/Command/LockedCustardCommand.php
+++ b/src/Command/LockedCustardCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Rhubarb\Custard\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class LockedCustardCommand extends CustardCommand
+{
+    protected $gotLock = false;
+
+    protected static $isDebugMode = false;
+
+    public function run(InputInterface $input, OutputInterface $output)
+    {
+        $this->lock($input, $output);
+        try {
+            parent::run($input, $output);
+        } finally {
+            $this->release();
+        }
+    }
+
+    /**
+     * @return string Must be a single character e.g. 'a'
+     */
+    protected function getLockFile():string {
+        if (!is_dir(TEMP_DIR)) {
+            mkdir(TEMP_DIR, 0777, true);
+        }
+
+        return TEMP_DIR . md5($this->getName()) . '.lock';
+    }
+
+    protected function getLockTimeoutMins(): int {
+        return 5;
+    }
+
+    protected function lock(InputInterface $input, OutputInterface $output) {
+        if ($this::$isDebugMode) {
+            return;
+        }
+
+        $lockFile = $this->getLockFile();
+        $timeout = time() - ($this->getLockTimeoutMins() * 60);
+        $fileModified = file_exists($lockFile) ? filemtime($lockFile) : 0;
+
+        if ($fileModified > $timeout) {
+            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $output->write('Command already running. If you are debugging, add \'protected static $isDebugMode = true;\' to the command.', true);
+            }
+
+            throw new \Exception('Command already running.');
+        }
+
+        if (!file_put_contents($lockFile, $this->getName() . ' ' . time())) {
+            throw new \Exception("Command failed to lock. There may be a permissions issue creating lock file '$lockFile'");
+        }
+
+        $this->gotLock = true;
+    }
+
+    protected function release() {
+        if (!$this->gotLock) {
+            return;
+        }
+
+        $lockFile = $this->getLockFile();
+        try {
+            if(file_exists($lockFile)) {
+                unlink($lockFile);
+            }
+        } catch (\Exception $e){}
+    }
+}


### PR DESCRIPTION
run a single instance at a time

Useful for repetitive cron jobs where only one instance should run at
any time